### PR TITLE
Add uniquegrouplist

### DIFF
--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,0 +1,5 @@
+package seedu.address.model.group;
+
+public class Group {
+    // Stub
+}

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -1,0 +1,5 @@
+package seedu.address.model.group;
+
+public class UniqueGroupList {
+    // Stub
+}

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -1,5 +1,137 @@
 package seedu.address.model.group;
 
-public class UniqueGroupList {
-    // Stub
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.group.exceptions.DuplicateGroupException;
+import seedu.address.model.group.exceptions.GroupNotFoundException;
+
+/**
+ * A list of groups that enforces uniqueness between its elements and does not allow nulls.
+ * A group is considered unique by comparing using {@code Group#isSameGroup(Group)}. As such, adding and updating of
+ * groups uses Group#isSameGroup(Group) for equality so as to ensure that the group being added or updated is
+ * unique in terms of identity in the UniqueGroupList. However, the removal of a group uses Group#equals(Object) so
+ * as to ensure that the group with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Group#isSameGroup(Group)
+ */
+public class UniqueGroupList implements Iterable<Group> {
+
+    private final ObservableList<Group> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Group> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent group as the given argument.
+     */
+    public boolean contains(Group toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameGroup);
+    }
+
+    /**
+     * Adds a group to the list.
+     * The group must not already exist in the list.
+     */
+    public void add(Group toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateGroupException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the group {@code target} in the list with {@code editedGroup}.
+     * {@code target} must exist in the list.
+     * The group identity of {@code editedGroup} must not be the same as another existing group in the list.
+     */
+    public void setGroup(Group target, Group editedGroup) {
+        requireAllNonNull(target, editedGroup);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new GroupNotFoundException();
+        }
+
+        if (!target.isSameGroup(editedGroup) && contains(editedGroup)) {
+            throw new DuplicateGroupException();
+        }
+
+        internalList.set(index, editedGroup);
+    }
+
+    /**
+     * Removes the equivalent group from the list.
+     * The group must exist in the list.
+     */
+    public void remove(Group toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new GroupNotFoundException();
+        }
+    }
+
+    public void setGroups(UniqueGroupList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code groups}.
+     * {@code groups} must not contain duplicate groups.
+     */
+    public void setGroups(List<Group> groups) {
+        requireAllNonNull(groups);
+        if (!groupsAreUnique(groups)) {
+            throw new DuplicateGroupException();
+        }
+
+        internalList.setAll(groups);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Group> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Group> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueGroupList // instanceof handles nulls
+                && internalList.equals(((UniqueGroupList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code groups} contains only unique groups.
+     */
+    private boolean groupsAreUnique(List<Group> groups) {
+        for (int i = 0; i < groups.size() - 1; i++) {
+            for (int j = i + 1; j < groups.size(); j++) {
+                if (groups.get(i).isSameGroup(groups.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.group.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Groups (Groups are considered duplicates if they have the same
+ * name).
+ */
+public class DuplicateGroupException extends RuntimeException {
+    public DuplicateGroupException() {
+        super("Operation would result in duplicate groups");
+    }
+}

--- a/src/main/java/seedu/address/model/group/exceptions/GroupNotFoundException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/GroupNotFoundException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.group.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified group.
+ */
+public class GroupNotFoundException extends RuntimeException {
+    public GroupNotFoundException() {
+        super("Specified group cannot be found");
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE YET**

Add support for the exact same operations as UniquePersonList.

Supporting: contains, add, setGroup, remove, setGroups, iteration, asUnmodifiableObservableList, groupsAreUnique.

Implementation may be up to change based on future requirements/developments.

Currently does not work. Requires Group#isSameGroup(Group) to be implemented.

Resolves #51 