### PR TITLE
Change Student to reference Group by GroupName only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '8.29'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -6,13 +6,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM_HANDLE;
 
-import java.util.List;
-
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.group.Group;
-import seedu.address.model.group.GroupContainsKeywordsPredicate;
-import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Student;
 
 
@@ -58,17 +53,13 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
         }
 
-        if (!model.hasGroup(toAdd.getGroup())) {
+        // Check that given groupName can identify an existing group in the model
+        if (!model.hasGroup(toAdd.getGroupName())) {
             throw new CommandException(MESSAGE_GROUP_NONEXISTENT);
         }
 
-        // Retrieve existing group in model
-        GroupName groupName = toAdd.getGroup().getGroupName();
-        model.updateFilteredGroupList(new GroupContainsKeywordsPredicate(List.of(groupName.toString())));
-        Group retrievedGroup = model.getFilteredGroupList().get(0);
-
         Student studentToAdd =
-                new Student(toAdd.getName(), toAdd.getTelegramHandle(), toAdd.getEmail(), retrievedGroup);
+                new Student(toAdd.getName(), toAdd.getTelegramHandle(), toAdd.getEmail(), toAdd.getGroupName());
 
         // Add student with the group fetched from the data in the model
         model.addStudent(studentToAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -15,8 +15,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.group.Group;
-import seedu.address.model.group.GroupContainsKeywordsPredicate;
 import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -98,18 +96,13 @@ public class EditCommand extends Command {
         TelegramHandle updatedTelegramHandle = editStudentDescriptor.getTelegramHandle()
             .orElse(studentToEdit.getTelegramHandle());
         Email updatedEmail = editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail());
-        Group updatedGroup = editStudentDescriptor.getGroup().orElse(studentToEdit.getGroup());
+        GroupName updatedGroupName = editStudentDescriptor.getGroupName().orElse(studentToEdit.getGroupName());
 
-        if (!model.hasGroup(updatedGroup)) {
+        if (!model.hasGroup(updatedGroupName)) {
             throw new CommandException(MESSAGE_GROUP_NONEXISTENT);
         }
 
-        // Retrieve existing group in model
-        GroupName groupName = updatedGroup.getGroupName();
-        model.updateFilteredGroupList(new GroupContainsKeywordsPredicate(List.of(groupName.toString())));
-        Group retrievedUpdatedGroup = model.getFilteredGroupList().get(0);
-
-        return new Student(updatedName, updatedTelegramHandle, updatedEmail, retrievedUpdatedGroup);
+        return new Student(updatedName, updatedTelegramHandle, updatedEmail, updatedGroupName);
     }
 
     @Override
@@ -138,7 +131,7 @@ public class EditCommand extends Command {
         private Name name;
         private TelegramHandle telegramHandle;
         private Email email;
-        private Group group;
+        private GroupName groupName;
 
         public EditStudentDescriptor() {
         }
@@ -150,7 +143,7 @@ public class EditCommand extends Command {
             setName(toCopy.name);
             setTelegramHandle(toCopy.telegramHandle);
             setEmail(toCopy.email);
-            setGroup(toCopy.group);
+            setGroupName(toCopy.groupName);
         }
 
         /**
@@ -184,12 +177,12 @@ public class EditCommand extends Command {
             return Optional.ofNullable(email);
         }
 
-        public void setGroup(Group group) {
-            this.group = group;
+        public void setGroupName(GroupName groupName) {
+            this.groupName = groupName;
         }
 
-        public Optional<Group> getGroup() {
-            return Optional.ofNullable(group);
+        public Optional<GroupName> getGroupName() {
+            return Optional.ofNullable(groupName);
         }
 
 
@@ -211,7 +204,7 @@ public class EditCommand extends Command {
             return getName().equals(e.getName())
                 && getTelegramHandle().equals(e.getTelegramHandle())
                 && getEmail().equals(e.getEmail())
-                && getGroup().equals(e.getGroup());
+                && getGroupName().equals(e.getGroupName());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -10,8 +10,6 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.group.Description;
-import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -43,9 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get());
 
-        // Actual description will be grabbed from group that should already exist in csBook
-        Group group = new Group(groupName, new Description("placeholder"));
-        Student student = new Student(name, telegramHandle, email, group);
+        Student student = new Student(name, telegramHandle, email, groupName);
 
         return new AddCommand(student);
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -11,8 +11,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditStudentDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.group.Description;
-import seedu.address.model.group.Group;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -49,9 +47,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             editStudentDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_GROUP_NAME).isPresent()) {
-            editStudentDescriptor.setGroup(
-                    new Group(ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get()),
-                            new Description("placeholder")));
+            editStudentDescriptor.setGroupName(
+                    ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).get()));
         }
         if (!editStudentDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/model/CsBook.java
+++ b/src/main/java/seedu/address/model/CsBook.java
@@ -134,7 +134,6 @@ public class CsBook implements ReadOnlyCsBook {
         groups.remove(key);
     }
 
-
     /**
      * Replaces the given student {@code target} in the list with {@code editedStudent}.
      * {@code target} must exist in the address book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Student;
 
 /**
@@ -47,7 +48,7 @@ public interface Model {
     void setCsBookFilePath(Path csBookFilePath);
 
     /**
-     * Replaces address book data with the data in {@code csBook}.
+     * Replaces model data with the data in {@code csBook}.
      */
     void setCsBook(ReadOnlyCsBook csBook);
 
@@ -61,19 +62,19 @@ public interface Model {
 
     /**
      * Deletes the given student.
-     * The student must exist in the address book.
+     * The student must exist in the model.
      */
     void deleteStudent(Student target);
 
     /**
      * Adds the given student.
-     * {@code student} must not already exist in the address book.
+     * {@code student} must not already exist in the model.
      */
     void addStudent(Student student);
 
     /**
      * Replaces the given student {@code target} with {@code editedStudent}.
-     * {@code target} must exist in the address book.
+     * {@code target} must exist in the model.
      * The student identity of {@code editedStudent} must not be the same as another existing student in the address
      * book.
      */
@@ -90,29 +91,39 @@ public interface Model {
 
 
     /**
-     * Returns true if a group with the same identity as {@code group} exists in the address book.
+     * Returns true if a group with the same identity as {@code group} exists in the model.
      */
     boolean hasGroup(Group group);
 
     /**
+     * Returns true if a group with the same groupName as {@code groupName} exists in the model.
+     */
+    boolean hasGroup(GroupName groupName);
+
+    /**
      * Deletes the given group.
-     * The group must exist in the address book.
+     * The group must exist in the model.
      */
     void deleteGroup(Group target);
 
     /**
      * Adds the given group.
-     * {@code group} must not already exist in the address book.
+     * {@code group} must not already exist in the model.
      */
-    void addGroup(Group group); //TODO to implement in 1.2b
+    void addGroup(Group group);
+
+    /**
+     * Returns the group in the model, identified by the given {@code groupName}
+     */
+    Group getGroupByGroupName(GroupName groupName);
 
     ///**
     // * Replaces the given group {@code target} with {@code editedGroup}.
-    // * {@code target} must exist in the address book.
+    // * {@code target} must exist in the model.
     // * The group identity of {@code editedGroup} must not be the same as another existing group in the address
     // * book.
     // */
-    // void setGroup(Group target, Group editedGroup); //TODO to implement in 1.2b
+    // void setGroup(Group target, Group editedGroup); //TODO to implement in 1.3
 
     /** Returns an unmodifiable view of the filtered group list */
     ObservableList<Group> getFilteredGroupList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -105,9 +105,7 @@ public class ModelManager implements Model {
     public void deleteStudent(Student target) {
         // Retrieve existing group in model
         GroupName groupName = target.getGroupName();
-        updateFilteredGroupList(new GroupContainsKeywordsPredicate(List.of(groupName.toString())));
-        Group retrievedGroup = getFilteredGroupList().get(0);
-        updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+        Group retrievedGroup = getGroupByGroupName(groupName);
 
         // Remove reference to student from the group that the student belonged to
         retrievedGroup.removeStudent(target);
@@ -119,9 +117,7 @@ public class ModelManager implements Model {
     public void addStudent(Student student) {
         // Retrieve existing group in model
         GroupName groupName = student.getGroupName();
-        updateFilteredGroupList(new GroupContainsKeywordsPredicate(List.of(groupName.toString())));
-        Group retrievedGroup = getFilteredGroupList().get(0);
-        updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+        Group retrievedGroup = getGroupByGroupName(groupName);
 
         // Add reference to student into the group
         retrievedGroup.addStudent(student);
@@ -143,6 +139,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasGroup(GroupName groupName) {
+        requireAllNonNull(groupName);
+        return getGroupByGroupName(groupName) != null;
+    }
+
+    @Override
     public void deleteGroup(Group target) {
         Set<Student> studentsToDelete = target.getStudents();
 
@@ -158,6 +160,22 @@ public class ModelManager implements Model {
     public void addGroup(Group group) {
         csBook.addGroup(group);
         updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+    }
+
+    @Override
+    public Group getGroupByGroupName(GroupName groupName) {
+        updateFilteredGroupList(new GroupContainsKeywordsPredicate(List.of(groupName.toString())));
+
+        // return null if the group is not found
+        if (getFilteredGroupList().isEmpty()) {
+            updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+            return null;
+        }
+
+        Group retrievedGroup = getFilteredGroupList().get(0);
+        updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+
+        return retrievedGroup;
     }
 
     //=========== Filtered Student List Accessors =============================================================

--- a/src/main/java/seedu/address/model/student/ContainsGroupNamePredicate.java
+++ b/src/main/java/seedu/address/model/student/ContainsGroupNamePredicate.java
@@ -15,7 +15,7 @@ public class ContainsGroupNamePredicate implements Predicate<Student> {
     @Override
     public boolean test(Student student) {
         //TODO : Change student.getGroup().getGroupName() to student.getGroupName() once we change student group field
-        return groupName.equals(student.getGroup().getGroupName());
+        return groupName.equals(student.getGroupName());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
-import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 
 /**
@@ -19,17 +18,17 @@ public class Student {
     private final Email email;
 
     // Data fields
-    private final Group group;
+    private final GroupName groupName;
 
     /**
      * Every field must be present and not null.
      */
-    public Student(Name name, TelegramHandle telegramHandle, Email email, Group group) {
-        requireAllNonNull(name, telegramHandle, email, group);
+    public Student(Name name, TelegramHandle telegramHandle, Email email, GroupName groupName) {
+        requireAllNonNull(name, telegramHandle, email, groupName);
         this.name = name;
         this.telegramHandle = telegramHandle;
         this.email = email;
-        this.group = group;
+        this.groupName = groupName;
     }
 
     public Name getName() {
@@ -44,12 +43,8 @@ public class Student {
         return email;
     }
 
-    public Group getGroup() {
-        return group;
-    }
-
     public GroupName getGroupName() {
-        return group.getGroupName();
+        return groupName;
     }
 
     /**
@@ -83,13 +78,13 @@ public class Student {
         return otherStudent.getName().equals(getName())
                 && otherStudent.getTelegramHandle().equals(getTelegramHandle())
                 && otherStudent.getEmail().equals(getEmail())
-                && otherStudent.getGroup().equals(getGroup());
+                && otherStudent.getGroupName().equals(getGroupName());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, telegramHandle, email, getGroupName());
+        return Objects.hash(name, telegramHandle, email, groupName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -17,18 +17,17 @@ public class SampleDataUtil {
     public static Student[] getSampleStudents() {
         return new Student[]{
             new Student(new Name("Alex Yeoh"), new TelegramHandle("@alex_yeoh"), new Email("alexyeoh@example.com"),
-                new Group(new GroupName("CS2103T"), new Description("SWE Module"))),
+                    new GroupName("CS2103T")),
             new Student(new Name("Bernice Yu"), new TelegramHandle("@bernice_yu"), new Email("berniceyu@example.com"),
-                new Group(new GroupName("CS2103T"), new Description("SWE Module"))),
+                    new GroupName("CS2103T")),
             new Student(new Name("Charlotte Oliveiro"), new TelegramHandle("@charlotte"),
-                    new Email("charlotte@example.com"), new Group(new GroupName("CS2103T"),
-                    new Description("SWE Module"))),
+                    new Email("charlotte@example.com"), new GroupName("CS2103T")),
             new Student(new Name("David Li"), new TelegramHandle("@david_li"), new Email("lidavid@example.com"),
-                new Group(new GroupName("CS2103T"), new Description("SWE Module"))),
+                    new GroupName("CS2103T")),
             new Student(new Name("Irfan Ibrahim"), new TelegramHandle("@irfan_ibrahim"), new Email("irfan@example.com"),
-                new Group(new GroupName("CS2103T"), new Description("SWE Module"))),
+                    new GroupName("CS2103T")),
             new Student(new Name("Roy Balakrishnan"), new TelegramHandle("@roy_balakrishnan"),
-                    new Email("royb@example.com"), new Group(new GroupName("CS2103T"), new Description("SWE Module")))
+                    new Email("royb@example.com"), new GroupName("CS2103T"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedStudent.java
@@ -7,15 +7,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.group.Description;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.TelegramHandle;
-
-
 
 /**
  * Jackson-friendly version of {@link Student}.
@@ -51,7 +48,7 @@ class JsonAdaptedStudent {
         name = source.getName().fullName;
         telegramHandle = source.getTelegramHandle().value;
         email = source.getEmail().value;
-        groupName = source.getGroup().getGroupName().toString();
+        groupName = source.getGroupName().toString();
     }
 
     /**
@@ -89,29 +86,29 @@ class JsonAdaptedStudent {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                 GroupName.class.getSimpleName()));
         }
-
+        if (!GroupName.isValidName(groupName)) {
+            throw new IllegalValueException(GroupName.MESSAGE_CONSTRAINTS);
+        }
         final GroupName modelGroupName = new GroupName(groupName);
 
-        Group modelGroup = retrieveByName(modelGroupName, groupList);
+        if (!groupExistsInGroupList(modelGroupName, groupList)) {
+            throw new IllegalValueException(MESSAGE_GROUP_NAME_NOT_FOUND);
+        }
 
-        return new Student(modelName, modelTelegramHandle, modelEmail, modelGroup);
+        return new Student(modelName, modelTelegramHandle, modelEmail, modelGroupName);
     }
 
     /**
-     * Returns a {@code Group} from a given group list that matches the given {@code GroupName}.
+     * Returns true if the name of a {@code Group} from a given group list matches the given {@code GroupName}.
      * @return group from the group list that matches the given group name
-     * @throws IllegalValueException if no group that matches the groupName can be found.
      */
-    public Group retrieveByName(GroupName groupName, ObservableList<Group> groupList) throws IllegalValueException {
+    public boolean groupExistsInGroupList(GroupName groupName, ObservableList<Group> groupList) {
         requireNonNull(groupName);
         for (Group group : groupList) {
             if (group.getGroupName().equals(groupName)) {
-                String groupNameString = groupName.toString();
-                String descriptionString = group.getDescription().toString();
-                return new Group(new GroupName(groupNameString),
-                        new Description(descriptionString));
+                return true;
             }
         }
-        throw new IllegalValueException(MESSAGE_GROUP_NAME_NOT_FOUND);
+        return false;
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableCsBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableCsBook.java
@@ -88,12 +88,12 @@ class JsonSerializableCsBook {
         ObservableList<Group> groupList = csBook.getGroupList();
         for (Group groupWithoutStudentList : groupList) {
             List<Student> studentsInGroup = csBook.getStudentList().stream()
-                    .filter(student -> student.getGroup().equals(groupWithoutStudentList)).collect(Collectors.toList());
+                    .filter(student -> student.getGroupName().equals(groupWithoutStudentList.getGroupName()))
+                    .collect(Collectors.toList());
             Group groupWithStudentList = new Group(groupWithoutStudentList.getGroupName(),
                     groupWithoutStudentList.getDescription());
             groupWithStudentList.addAllStudents(studentsInGroup);
             csBook.setGroup(groupWithoutStudentList, groupWithStudentList);
         }
     }
-
 }

--- a/src/main/java/seedu/address/ui/StudentCard.java
+++ b/src/main/java/seedu/address/ui/StudentCard.java
@@ -44,7 +44,7 @@ public class StudentCard extends UiPart<Region> {
         this.student = student;
         id.setText(displayedIndex + ". ");
         name.setText(student.getName().fullName);
-        groupName.setText(student.getGroup().getGroupName().toString());
+        groupName.setText(student.getGroupName().toString());
         telegramHandle.setText(student.getTelegramHandle().value);
         email.setText(student.getEmail().value);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyCsBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Student;
 import seedu.address.testutil.StudentBuilder;
 
@@ -158,12 +159,22 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasGroup(GroupName groupName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteGroup(Group target) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void addGroup(Group group) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Group getGroupByGroupName(GroupName groupName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -69,11 +69,11 @@ public class CommandTestUtil {
 
     static {
         DESC_AMY = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withTelegramHandle(VALID_TELEGRAM_HANDLE_AMY).withEmail(VALID_EMAIL_AMY).withGroup(
-                        VALID_GROUP_NAME_AMY, VALID_DESC_AMY).build();
+                .withTelegramHandle(VALID_TELEGRAM_HANDLE_AMY).withEmail(VALID_EMAIL_AMY).withGroupName(
+                        VALID_GROUP_NAME_AMY).build();
         DESC_BOB = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB).withEmail(VALID_EMAIL_BOB).withGroup(
-                        VALID_GROUP_NAME_BOB, VALID_DESC_BOB).build();
+                .withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB).withEmail(VALID_EMAIL_BOB).withGroupName(
+                        VALID_GROUP_NAME_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ViewGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewGroupCommandTest.java
@@ -30,11 +30,11 @@ public class ViewGroupCommandTest {
     public void setUp() {
         List<Group> testGroups = Arrays.asList(new Group(new GroupName("CS2103T"), new Description("SWE Module")));
         Student validStudent1 = new StudentBuilder().withName("Erin")
-                .withGroup("CS2103T", "SWE Module").build();
+                .withGroupName("CS2103T").build();
         Student validStudent2 = new StudentBuilder().withName("Monkey")
-                .withGroup("CS2103T", "SWE Module").build();
+                .withGroupName("CS2103T").build();
         Student validStudent3 = new StudentBuilder().withName("Pei Xian")
-                .withGroup("CS2101", "SWE Module").build();
+                .withGroupName("CS2101").build();
         List<Student> testStudents = Arrays.asList(validStudent1, validStudent2, validStudent3);
         CsBook csBook = getTypicalCsBook();
         csBook.setGroups(testGroups);

--- a/src/test/java/seedu/address/model/student/ContainsGroupNamePredicateTest.java
+++ b/src/test/java/seedu/address/model/student/ContainsGroupNamePredicateTest.java
@@ -39,14 +39,14 @@ class ContainsGroupNamePredicateTest {
     public void test_containsGroupName_returnsTrue() {
         ContainsGroupNamePredicate predicate = new ContainsGroupNamePredicate(new GroupName("CS2103T"));
         assertTrue(predicate.test(new StudentBuilder().withName("Alice")
-                .withGroup("CS2103T", "test").build()));
+                .withGroupName("CS2103T").build()));
     }
 
     @Test
     public void test_doesNotContainsGroupName_returnsFalse() {
         ContainsGroupNamePredicate predicate = new ContainsGroupNamePredicate(new GroupName("CS2103T"));
         assertFalse(predicate.test(new StudentBuilder().withName("Alice")
-                .withGroup("GEQ1000", "test").build()));
+                .withGroupName("GEQ1000").build()));
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -26,7 +26,7 @@ public class JsonAdaptedStudentTest {
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_TELEGRAM_HANDLE = BENSON.getTelegramHandle().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
-    private static final String VALID_GROUP_NAME = BENSON.getGroup().getGroupName().toString();
+    private static final String VALID_GROUP_NAME = BENSON.getGroupName().toString();
     private static final String VALID_DESCRIPTION = "A Software engineering module";
 
     //TODO Fix test case

--- a/src/test/java/seedu/address/testutil/EditStudentDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditStudentDescriptorBuilder.java
@@ -1,8 +1,6 @@
 package seedu.address.testutil;
 
 import seedu.address.logic.commands.EditCommand.EditStudentDescriptor;
-import seedu.address.model.group.Description;
-import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -61,19 +59,10 @@ public class EditStudentDescriptorBuilder {
     /**
      * Sets the {@code GroupName} of the {@code EditStudentDescriptor} that we are building.
      */
-    public EditStudentDescriptorBuilder withGroup(Group group) {
-        descriptor.setGroup(group);
+    public EditStudentDescriptorBuilder withGroupName(String groupName) {
+        descriptor.setGroupName(new GroupName(groupName));
         return this;
     }
-
-    /**
-     * Sets the {@code GroupName} of the {@code EditStudentDescriptor} that we are building.
-     */
-    public EditStudentDescriptorBuilder withGroup(String groupName, String description) {
-        descriptor.setGroup(new Group(new GroupName(groupName), new Description(description)));
-        return this;
-    }
-
 
     public EditStudentDescriptor build() {
         return descriptor;

--- a/src/test/java/seedu/address/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/address/testutil/StudentBuilder.java
@@ -1,7 +1,5 @@
 package seedu.address.testutil;
 
-import seedu.address.model.group.Description;
-import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -22,7 +20,7 @@ public class StudentBuilder {
     private Name name;
     private TelegramHandle telegramHandle;
     private Email email;
-    private Group group;
+    private GroupName groupName;
 
     /**
      * Creates a {@code StudentBuilder} with the default details.
@@ -31,7 +29,7 @@ public class StudentBuilder {
         name = new Name(DEFAULT_NAME);
         telegramHandle = new TelegramHandle(DEFAULT_TELEGRAM_HANDLE);
         email = new Email(DEFAULT_EMAIL);
-        group = new Group(new GroupName(DEFAULT_GROUP_NAME), new Description(DEFAULT_DESCRIPTION));
+        groupName = new GroupName(DEFAULT_GROUP_NAME);
     }
 
     /**
@@ -41,7 +39,7 @@ public class StudentBuilder {
         name = studentToCopy.getName();
         telegramHandle = studentToCopy.getTelegramHandle();
         email = studentToCopy.getEmail();
-        group = studentToCopy.getGroup();
+        groupName = studentToCopy.getGroupName();
     }
 
     /**
@@ -71,17 +69,16 @@ public class StudentBuilder {
     /**
      * Sets the {@code GroupName} of the {@code Student} that we are building.
      */
-    public StudentBuilder withGroup(String groupName, String description) {
-        this.group = new Group(new GroupName(groupName), new Description(description));
+    public StudentBuilder withGroupName(String groupName) {
+        this.groupName = new GroupName(groupName);
         return this;
     }
 
     /**
      * Sets the {@code GroupName} of the {@code Student} that we are building.
      */
-    public StudentBuilder withGroup(Group group) {
-        this.group = new Group(new GroupName(group.getGroupName().toString()),
-                new Description(group.getDescription().toString()));
+    public StudentBuilder withGroupName(GroupName groupName) {
+        this.groupName = new GroupName(groupName.toString());
         return this;
     }
 
@@ -90,8 +87,7 @@ public class StudentBuilder {
      * @return built student
      */
     public Student build() {
-        // TODO Double confirm, do we need to load a group from the model for this testUtil method/class?
-        return new Student(name, telegramHandle, email, group);
+        return new Student(name, telegramHandle, email, groupName);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/StudentUtil.java
+++ b/src/test/java/seedu/address/testutil/StudentUtil.java
@@ -29,7 +29,7 @@ public class StudentUtil {
         sb.append(PREFIX_NAME + student.getName().fullName + " ");
         sb.append(PREFIX_TELEGRAM_HANDLE + student.getTelegramHandle().value + " ");
         sb.append(PREFIX_EMAIL + student.getEmail().value + " ");
-        sb.append(PREFIX_GROUP_NAME + student.getGroup().getGroupName().toString() + " ");
+        sb.append(PREFIX_GROUP_NAME + student.getGroupName().toString() + " ");
 
         return sb.toString();
     }
@@ -44,7 +44,7 @@ public class StudentUtil {
                 .ifPresent(telegramHandle -> sb.append(PREFIX_TELEGRAM_HANDLE).append(telegramHandle.value)
                 .append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
-        descriptor.getGroup().ifPresent(group -> sb.append(PREFIX_GROUP_NAME).append(group.getGroupName().toString())
+        descriptor.getGroupName().ifPresent(groupName -> sb.append(PREFIX_GROUP_NAME).append(groupName.toString())
                 .append(" "));
 
         return sb.toString();

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -1,7 +1,5 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_AMY;
@@ -12,7 +10,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_HANDLE
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_HANDLE_BOB;
 import static seedu.address.testutil.TypicalGroups.TYPICAL_GROUP_CS2101;
 import static seedu.address.testutil.TypicalGroups.TYPICAL_GROUP_CS2103T;
-import static seedu.address.testutil.TypicalGroups.TYPICAL_GROUP_CS2103T_DESC;
 import static seedu.address.testutil.TypicalGroups.TYPICAL_GROUP_CS2103T_NAME;
 
 import java.util.ArrayList;
@@ -29,40 +26,40 @@ public class TypicalStudents {
 
     public static final Student ALICE = new StudentBuilder().withName("Alice Pauline").withEmail("alice@example.com")
             .withTelegramHandle("@alice_pauline")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student BENSON = new StudentBuilder().withName("Benson Meier").withEmail("johnd@example.com")
             .withTelegramHandle("@benson_meier")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withEmail("heinz@example.com")
             .withTelegramHandle("@carl_kurz")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withEmail("cornelia@example.com")
             .withTelegramHandle("@daniel_meier")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withTelegramHandle("@elle_meyer")
             .withEmail("werner@example.com")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz").withTelegramHandle("@fiona_kunz")
             .withEmail("lydia@example.com")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student GEORGE = new StudentBuilder().withName("George Best").withTelegramHandle("@george_best")
             .withEmail("anna@example.com")
-            .withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
 
     // Manually added
     public static final Student HOON = new StudentBuilder().withName("Hoon Meier").withTelegramHandle("@hoon_meier")
-            .withEmail("stefan@example.com").withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withEmail("stefan@example.com").withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
     public static final Student IDA = new StudentBuilder().withName("Ida Mueller").withTelegramHandle("@ida_mueller")
-            .withEmail("hans@example.com").withGroup(TYPICAL_GROUP_CS2103T_NAME, TYPICAL_GROUP_CS2103T_DESC).build();
+            .withEmail("hans@example.com").withGroupName(TYPICAL_GROUP_CS2103T_NAME).build();
 
     // Manually added - Student's details found in {@code CommandTestUtil}
     public static final Student AMY = new StudentBuilder().withName(VALID_NAME_AMY)
             .withTelegramHandle(VALID_TELEGRAM_HANDLE_AMY).withEmail(VALID_EMAIL_AMY)
-            .withGroup(new GroupBuilder().withGroupName(VALID_GROUP_NAME_AMY).withDescription(VALID_DESC_AMY).build())
+            .withGroupName(VALID_GROUP_NAME_AMY)
             .build();
     public static final Student BOB = new StudentBuilder().withName(VALID_NAME_BOB)
             .withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB).withEmail(VALID_EMAIL_BOB)
-            .withGroup(new GroupBuilder().withGroupName(VALID_GROUP_NAME_BOB).withDescription(VALID_DESC_BOB).build())
+            .withGroupName(VALID_GROUP_NAME_BOB)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Change all Student to store references to groups that they belong to by storing only the GroupName instead of the previous implementation of Group in order to reduce coupling.

Resolves #83 