### PR TITLE
Fix `edit` not allowing edit when `g/GROUP_NAME` is the only parameter given

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -152,7 +152,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, telegramHandle, email);
+            return CollectionUtil.isAnyNonNull(name, telegramHandle, email, groupName);
         }
 
         public void setName(Name name) {


### PR DESCRIPTION
Resolves #118 